### PR TITLE
Remove security scan job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,33 +50,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  security:
-    name: 🔒 Security Scan
-    runs-on: ubuntu-latest
-    needs: test
-    
-    steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@v4
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: 📦 Install dependencies
-        run: npm ci
-
-      - name: 🔍 Security audit
-        run: npm audit --audit-level high
-
-      - name: 🛡️ Run security scan
-        uses: securecodewarrior/github-action-add-sarif@v1
-        if: always()
-        with:
-          sarif-file: 'security-scan-results.sarif'
-
   docker:
     name: 🐳 Docker Build & Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Removed entire security job including npm audit and SARIF scanning
- Simplified CI pipeline by removing security scanning steps